### PR TITLE
fix multichannel audio issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.20.3
-librosa==0.8.1
+librosa==0.9.2
 pyyaml==5.4.1
 types-PyYAML==5.4.6


### PR DESCRIPTION
Using librosa==0.9.2 would allow multichannel audio pre-processing in the full pipeline.